### PR TITLE
Fix for zf generate-migration command

### DIFF
--- a/library/ZFDoctrine/Tool/DoctrineProvider.php
+++ b/library/ZFDoctrine/Tool/DoctrineProvider.php
@@ -302,7 +302,10 @@ class ZFDoctrine_Tool_DoctrineProvider extends Zend_Tool_Project_Provider_Abstra
 
     public function generateMigration($className=null, $dFromDatabase=false, $mFromModels=false)
     {
-        $migrationsPath = $this->_getMigrationsDirectoryPath();
+
+        $this->_initDoctrineResource();
+
+        $migratePath = $this->_getMigrationsDirectoryPath();
 
         if ($className) {
             Doctrine_Core::generateMigrationClass($className, $migratePath);
@@ -310,7 +313,6 @@ class ZFDoctrine_Tool_DoctrineProvider extends Zend_Tool_Project_Provider_Abstra
             $this->_print('Successfully generated migration class '.$className.'.', array('color' => 'green'));
             $this->_print('Destination Directory: '.$migratePath);
         } else if ($dFromDatabase) {
-            $this->_initDoctrineResource();
 
             $yamlSchemaPath = $this->_getYamlDirectoryPath();
             $migration = new Doctrine_Migration($migrationsPath);


### PR DESCRIPTION
Hi Ben,

I've been having great success using zf-doctrine, however it definitely seems as if the migration feature is broken. A glance at DoctrineProvider.php indicates that this was due to a misnamed variable ($migrationsPath instead of $migratePath) and a misplaced call to $this->_initDoctrineResource(). I've fixed these issues within this doctrineproviderfix branch, and a migration is now being created (and the errors have disappeared). 

Unfortunately it is unclear what exactly this migration file (which is successfully generated within the migrations directory is supposed to look like. A look at a generated migration file (generated with my patch in place) shows empty up() and empty() down methods which clearly seems incorrect. Nonetheless, the two changes found in this patch strike me as a step in the right direction towards fixing this problem.

Could you confirm and let me know? Happy to keep helping you out with this project if you'd like me to.

Jason
