### PR TITLE
View Helper um frei wählbare Doctrine-Query erweitert

### DIFF
--- a/library/ZFDoctrine/View/Helper/ModelList.php
+++ b/library/ZFDoctrine/View/Helper/ModelList.php
@@ -61,7 +61,7 @@ class ZFDoctrine_View_Helper_ModelList extends Zend_View_Helper_Abstract
      * @param array $options
      * @return string
      */
-    public function modelList($modelName, array $options = array())
+    public function modelList($modelName, array $options = array(), Doctrine_Query_Abstract $query = null)
     {
         $options = array_merge(self::$_defaultOptions, $options);
 
@@ -70,7 +70,12 @@ class ZFDoctrine_View_Helper_ModelList extends Zend_View_Helper_Abstract
         }
 
         $table = Doctrine_Core::getTable($modelName);
-        $adapter = new ZFDoctrine_Paginator_Adapter_DoctrineQuery($table->createQuery());
+
+        if (!$query) {
+          $query = $table->createQuery();
+        }
+
+        $adapter = new ZFDoctrine_Paginator_Adapter_DoctrineQuery($query);
         $paginator = new Zend_Paginator($adapter);
 
         $front = Zend_Controller_Front::getInstance();


### PR DESCRIPTION
Hallo Benny (darf man dich so abkürzen? Schaut so aus in der Readme im Rechnernamen im Prompt),

brauchte für ein Projekt die Möglichkeit nicht alle Einträge einer Tabelle sondern nur solche die einem bestimmten Query entsprechen zu listen und habe daher den Helfer entsprechend um einen Parameter erweitert.

Magst Du das in Deinen master pullen?

Liebe Grüße
Jan
