### PR TITLE
Fix für ZFDoctrine_Form_Model required Elemente

### DIFF
--- a/library/ZFDoctrine/Form/Model.php
+++ b/library/ZFDoctrine/Form/Model.php
@@ -308,7 +308,7 @@ class ZFDoctrine_Form_Model extends Zend_Form
                     $field->addMultiOption($text, ucwords($text));
                 }
             } else if($definition['foreignKey'] && $field instanceof Zend_Form_Element_Multi) {
-                $options = array('------');
+                $options = array(null => '------');
                 foreach ($this->_adapter->getAllRecords($definition['class']) AS $record) {
                     $options[$this->_adapter->getRecordIdentifier($record)] = (string)$record;
                 }


### PR DESCRIPTION
Hallo,

ich hab da nen kleinen Fix im Angebot.
Durch die default-Einstellungen des NotEmpty Validators der sich durch diese nicht um Integer-Werte kümmert (also 0 ist nicht empty) muss man da explizit einen NULL-Wert für die leere Auswahl reinwerfen, sonst schlägt der Validator nicht an und es kracht tiefer unten in Doctrine.

greetz,
Jan
