### PR TITLE
Fix migration variable typo and add support for custom hydrators

### DIFF
--- a/library/ZFDoctrine/Application/Resource/Doctrine.php
+++ b/library/ZFDoctrine/Application/Resource/Doctrine.php
@@ -96,6 +96,22 @@ class ZFDoctrine_Application_Resource_Doctrine extends Zend_Application_Resource
     }
 
     /**
+     *
+     * @param Doctrine_Configurable $object
+     * @param array $attributes
+     * @return void
+     */
+    protected function _setHydrators(Doctrine_Configurable $object, array $attributes)
+    {
+        foreach ($attributes as $key => $value) {
+            if (!isset($key)) {
+                throw new Zend_Application_Resource_Exception('No name for hydrator defined. ' . $value);
+            }
+            $object->registerHydrator($key, $value);
+        }
+    }
+
+    /**
      * Set connection listeners
      *
      * @param   Doctrine_Connection_Common $conn
@@ -270,6 +286,11 @@ class ZFDoctrine_Application_Resource_Doctrine extends Zend_Application_Resource
         $manager = Doctrine_Manager::getInstance();
         $manager->setAttribute(Doctrine_Core::ATTR_MODEL_LOADING, ZFDoctrine_Core::MODEL_LOADING_ZEND); // default
         
+
+        if (array_key_exists('hydrators', $this->_managerOptions)) {
+            $this->_setHydrators($manager, $this->_managerOptions['hydrators']);
+        }
+
         if (array_key_exists('attributes', $this->_managerOptions)) {
             $this->_setAttributes($manager, $this->_managerOptions['attributes']);
         }

--- a/library/ZFDoctrine/Tool/DoctrineProvider.php
+++ b/library/ZFDoctrine/Tool/DoctrineProvider.php
@@ -315,16 +315,16 @@ class ZFDoctrine_Tool_DoctrineProvider extends Zend_Tool_Project_Provider_Abstra
         } else if ($dFromDatabase) {
 
             $yamlSchemaPath = $this->_getYamlDirectoryPath();
-            $migration = new Doctrine_Migration($migrationsPath);
+            $migration = new Doctrine_Migration($migratePath);
             $result1 = false;
             if ( ! count($migration->getMigrationClasses())) {
-                $result1 = Doctrine_Core::generateMigrationsFromDb($migrationsPath);
+                $result1 = Doctrine_Core::generateMigrationsFromDb($migratePath);
             }
             $connections = array();
             foreach (Doctrine_Manager::getInstance() as $connection) {
                 $connections[] = $connection->getName();
             }
-            $changes = Doctrine_Core::generateMigrationsFromDiff($migrationsPath, $connections, $yamlSchemaPath);
+            $changes = Doctrine_Core::generateMigrationsFromDiff($migratePath, $connections, $yamlSchemaPath);
             $numChanges = count($changes, true) - count($changes);
             $result = ($result1 || $numChanges) ? true:false;
 
@@ -336,7 +336,7 @@ class ZFDoctrine_Tool_DoctrineProvider extends Zend_Tool_Project_Provider_Abstra
         } else if ($mFromModels) {
             $this->_loadDoctrineModels();
 
-            Doctrine_Core::generateMigrationsFromModels($migrationsPath, null);
+            Doctrine_Core::generateMigrationsFromModels($migratePath, null);
 
             $this->_print('Generated migration classes from the model successfully.');
         }


### PR DESCRIPTION
You can now add custom hydrators by having something like this in your application.ini

```
resources.doctrine.manager.hydrators[KeyValue] = "App_Doctrine_Hydrator_KeyValue"
```

Also fix the migration path variable issue :)
