### PR TITLE
model_loading_zend vs. pearStyle & generate-migration-diff

### DIFF
--- a/library/ZFDoctrine/Import/Builder.php
+++ b/library/ZFDoctrine/Import/Builder.php
@@ -34,6 +34,10 @@ class ZFDoctrine_Import_Builder extends Doctrine_Import_Builder
         $pos = strpos($originalClassName, 'Model_');
         $originalClassName = substr($originalClassName, $pos+6);
 
+        if ($this->_pearStyle) {
+            $originalClassName = str_replace('_', '/', $originalClassName);
+        }
+
         $file = $originalClassName . $this->_suffix;
 
         return $file;
@@ -49,7 +53,11 @@ class ZFDoctrine_Import_Builder extends Doctrine_Import_Builder
         $className = $definition['tableClassName'];
         $pos = strpos($className, "Model_");
         $fileName = substr($className, $pos+6) . $this->_suffix;
-        $writePath = $path . DIRECTORY_SEPARATOR . $fileName;
+        if ($this->_pearStyle) {
+            $writePath = $path . DIRECTORY_SEPARATOR . str_replace('_', '/', $fileName);
+        } else {
+            $writePath = $path . DIRECTORY_SEPARATOR . $fileName;
+        }
 
         $content = $this->buildTableClassDefinition($className, $definition, $options);
 

--- a/library/ZFDoctrine/Import/Schema.php
+++ b/library/ZFDoctrine/Import/Schema.php
@@ -91,7 +91,6 @@ class ZFDoctrine_Import_Schema extends Doctrine_Import_Schema
     public function getOptions()
     {
         $options = parent::getOptions();
-        $options['pearStyle'] = false;
         $options['baseClassesDirectory'] = 'Base';
         $options['baseClassPrefix'] = '';
         $options['classPrefix'] = '';

--- a/library/ZFDoctrine/Tool/DoctrineProvider.php
+++ b/library/ZFDoctrine/Tool/DoctrineProvider.php
@@ -342,6 +342,31 @@ class ZFDoctrine_Tool_DoctrineProvider extends Zend_Tool_Project_Provider_Abstra
         }
     }
 
+    public function generateMigrationDiff($fromSchemaPath, $toSchemaPath = null)
+    {
+        $this->_initDoctrineResource();
+
+        $migrationsPath = $this->_getMigrationsDirectoryPath();
+        $yamlSchemaPath = $this->_getYamlDirectoryPath();
+        if (null === $toSchemaPath) {
+            $toSchemaPath = $yamlSchemaPath;
+        }
+
+        Doctrine_Manager::getInstance()->setAttribute(
+            Doctrine_Core::ATTR_MODEL_LOADING, 
+            Doctrine_Core::MODEL_LOADING_CONSERVATIVE
+        );
+        spl_autoload_register(array('Doctrine_Core', 'modelsAutoload'));
+
+        Doctrine_Core::generateMigrationsFromDiff(
+            $migrationsPath,
+            $fromSchemaPath,
+            $toSchemaPath
+        );
+
+        $this->_print('Generated migration classes successfully.');
+    }
+
     public function executeMigration($toVersion = null)
     {
         $this->_initDoctrineResource();


### PR DESCRIPTION
model_loading_zend vs. pearStyle:
   https://github.com/beberlei/zf-doctrine/issues/33

generate-migration-diff:
   new Zend Tool action for generating migration classes of diff between to schema paths
